### PR TITLE
[Licensing] Restore KissFFT's stripped BSD notice; ship every third-p…

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -9,7 +9,7 @@ PocketTracker stands on a lot of excellent open-source work. Thank you to everyo
 | Library | License | Use in PocketTracker |
 |---|---|---|
 | [Oboe](https://github.com/google/oboe) | Apache 2.0 | Low-latency Android audio stream |
-| [DaisySP](https://github.com/electro-smith/DaisySP) | MIT | SVF filter, ReverbSc, DelayLine, Compressor, Limiter, BitCrush |
+| [DaisySP](https://github.com/electro-smith/DaisySP) | MIT **and** LGPL-2.1 (mixed — see note) | SVF filter, ReverbSc, DelayLine, Compressor, Limiter, BitCrush |
 | [TinySoundFont](https://github.com/schellingb/TinySoundFont) | MIT | SF2 / SoundFont2 synthesizer (with per-channel rendering fork) |
 | [KissFFT](https://github.com/mborgerding/kissfft) | BSD-3-Clause | FFT for spectrum analyzer and transient detection |
 | [Soundpipe](https://github.com/PaulBatchelor/Soundpipe) (pareq stub) | MIT | Parametric EQ biquad |
@@ -17,10 +17,23 @@ PocketTracker stands on a lot of excellent open-source work. Thank you to everyo
 | [dr_libs](https://github.com/mackron/dr_libs) (dr_mp3 / dr_flac) | Public domain (MIT-0) | Native MP3 / FLAC decoding |
 | [stb_vorbis](https://github.com/nothings/stb) | Public domain (MIT) | Native OGG Vorbis decoding |
 | [libopus / opusfile](https://opus-codec.org/) | BSD-3-Clause | Native Opus decoding |
+| [nlohmann/json](https://github.com/nlohmann/json) | MIT | Parsing `.ptp` / `.pti` project + instrument JSON |
 | [Jetpack Compose](https://developer.android.com/jetpack/compose) | Apache 2.0 | Android UI toolkit |
 | [Kotlinx Serialization](https://github.com/Kotlin/kotlinx.serialization) | Apache 2.0 | JSON project save / load |
 
 Each library keeps its own license. PocketTracker as a whole is distributed under GPL-3.0-or-later (see [`LICENSE`](LICENSE)).
+
+**Full notices for everything compiled into the audio engine — the code that ships in both the APK
+and the Linux port — are in [`licenses/THIRD-PARTY-NOTICES.md`](licenses/THIRD-PARTY-NOTICES.md),**
+which is the single source of truth and travels inside the release artifact.
+
+> **Note on DaisySP:** it is not uniformly MIT. Of the eight files PocketTracker compiles, five are
+> MIT (`svf`, `overdrive`, `decimator`, `limiter`, `crossfade`) and **three are LGPL-2.1** —
+> `compressor` (GRAME / Centre National de Creation Musicale), `balance` (Barry Vercoe, john ffitch,
+> Gabriel Maldonado) and `reverbsc` (Sean Costello, Istvan Varga, Paul Batchelor) — because those
+> descend from Csound and Faust rather than from Electrosmith's own code. LGPL-2.1 §3 permits
+> applying the ordinary GPL v2 "or any later version", so they are distributed here under
+> GPL-3.0-or-later along with the rest of the app. Per-file detail in the notices file above.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ PocketTracker is built on excellent open-source work — Oboe, DaisySP, TinySoun
 
 Full attributions, licenses, and DSP algorithm references: [`CREDITS.md`](CREDITS.md).
 
+**Third-party license notices** for everything compiled into the audio engine — the code that ships
+in both the Android app and the Linux handheld port — are reproduced in full in
+[`licenses/THIRD-PARTY-NOTICES.md`](licenses/THIRD-PARTY-NOTICES.md).
+
 ---
 
 ## License
@@ -119,3 +123,8 @@ PocketTracker is free software: you can redistribute it and/or modify it under t
 It is distributed in the hope that it will be useful, but **without any warranty** — without even the implied warranty of merchantability or fitness for a particular purpose. See the [GNU General Public License](https://www.gnu.org/licenses/gpl-3.0.html) for details.
 
 Full license text: [`LICENSE`](LICENSE).
+
+PocketTracker statically links several third-party components, each under its own license (BSD-3-Clause,
+MIT, LGPL-2.1, and public-domain dedications). Their copyright notices and license terms are reproduced
+in [`licenses/THIRD-PARTY-NOTICES.md`](licenses/THIRD-PARTY-NOTICES.md), which also ships inside the
+Linux port's release archive.

--- a/licenses/THIRD-PARTY-NOTICES.md
+++ b/licenses/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,257 @@
+# Third-party notices
+
+PocketTracker is distributed under **GPL-3.0-or-later** (see `LICENSE` at the repo root).
+It statically links the components below, so **their notices travel with the binary**, not merely
+with the source tree that built it. A user who receives only the artifact must still receive these.
+
+This file is the single source of truth for the notices and is shipped verbatim in:
+
+- the **PortMaster zip** → `pockettracker/licenses/THIRD-PARTY-NOTICES.md` (`linux/build-portmaster.sh`)
+- the **repo** → `licenses/THIRD-PARTY-NOTICES.md`
+
+⚠️ **Scope: this file lists what is compiled into the ENGINE**, i.e. everything that ships in *both*
+the APK and the Linux port. Android-only dependencies (Oboe, Jetpack Compose, Kotlinx Serialization)
+are resolved by Gradle, are **not** in `native/`, and are covered by `CREDITS.md` instead — the Linux
+binary contains none of them (`native/CMakeLists.txt` gates Oboe behind `if(ANDROID)`).
+
+⚠️ **When you vendor a new library, add it here in the same commit.** The build asserts this file is
+present in the artifact, but no automated check can know a component was *added* — that part is a
+habit, not a guard.
+
+---
+
+## KissFFT — BSD-3-Clause
+
+Used for: FFT behind the spectrum analyzer and the transient detector (`native/kissfft/`).
+
+> ⚠️ **The vendored copy of KissFFT arrived with its notice stripped** — no copyright line existed in
+> any of the five files. BSD-3-Clause requires the notice be retained in **source** redistributions
+> and reproduced in **binary** ones, so both the header banner (restored in `native/kissfft/*`) and
+> this section are obligations, not courtesies. Copyright line and SPDX identifier taken from
+> upstream `COPYING` (github.com/mborgerding/kissfft).
+
+```
+Copyright (c) 2003-2010 Mark Borgerding. All rights reserved.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## DaisySP — MIT **and** LGPL-2.1 (mixed; see the split below)
+
+Used for: SVF filter, overdrive, decimator/bitcrush, limiter, compressor, crossfade, balance,
+ReverbSc (`native/effects/primitives/daisysp/`).
+
+⚠️ **DaisySP is not uniformly MIT, and the files PocketTracker compiles land on both sides.**
+Three of the eight are LGPL-2.1 because they descend from Csound and Faust/GRAME rather than from
+Electrosmith's own code. Verified by reading the banner of each compiled file:
+
+| File | Licence | Copyright |
+|---|---|---|
+| `svf` | MIT | (c) 2020 Electrosmith, Corp |
+| `overdrive` | MIT | (c) 2020 Electrosmith, Corp, Emilie Gillet |
+| `decimator` | MIT | (c) 2020 Electrosmith, Corp |
+| `limiter` | MIT | (c) 2020 Electrosmith, Corp, Emilie Gillet |
+| `crossfade` | MIT | (c) 2020 Electrosmith, Corp, Paul Batchelor |
+| **`compressor`** | **LGPL-2.1** | (c) 2023 Electrosmith, Corp, GRAME, Centre National de Creation Musicale |
+| **`balance`** | **LGPL-2.1** | (c) 2023 Electrosmith, Corp, Barry Vercoe, john ffitch, Gabriel Maldonado |
+| **`reverbsc`** | **LGPL-2.1** | (c) 2023 Electrosmith, Corp, Sean Costello, Istvan Varga, Paul Batchelor |
+
+**On the LGPL-2.1 three:** PocketTracker as a whole is GPL-3.0-or-later. LGPL-2.1 **§3** expressly
+permits applying "the ordinary GNU General Public License" version 2 "or any later version" to a
+given copy of the library, so these three are distributed here under **GPL-3.0-or-later**, and the
+`LICENSE` text shipped beside this file is their governing text. There is no compatibility problem —
+but the attribution above is required and was previously absent.
+
+The five MIT files are covered by the MIT text below.
+
+```
+MIT License
+
+Copyright (c) Electrosmith, Corp and the contributors named per-file above
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## TinySoundFont (tsf) — MIT
+
+Used for: SF2 / SoundFont2 synthesis, with a per-channel rendering fork (`native/vendor/tsf/`).
+Notice as carried in `tsf.h`.
+
+```
+Copyright (C) 2017-2025 Bernhard Schelling
+Based on SFZero, Copyright (C) 2012 Steve Folta (https://github.com/stevefolta/SFZero)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+---
+
+## Soundpipe (pareq) — MIT
+
+Used for: the parametric-EQ biquad (`native/effects/soundpipe/pareq.c`), a stub extracted from
+Soundpipe by Paul Batchelor (https://github.com/PaulBatchelor/Soundpipe). MIT text as above,
+copyright Paul Batchelor.
+
+---
+
+## skoomaDust — GPL-3.0-or-later (includes APComp, BSD-3-Clause)
+
+Used for: the lo-fi DUST effect chain (`native/effects/modules/dust-chain.{h,cpp}`), contributed by
+[@skoomabwoy](https://github.com/skoomabwoy/skoomaDust). Same licence as PocketTracker itself
+(GPL-3.0-or-later) — `LICENSE` is the governing text.
+
+It embeds the **APComp** FET compressor by **Alain Paul / AP Mastering**, under **BSD-3-Clause**;
+the copyright is preserved in `dust-chain.cpp`. BSD-3-Clause text as in the KissFFT section above,
+substituting that copyright holder.
+
+---
+
+## dr_libs — dr_mp3 / dr_flac — public domain **or** MIT-0 (dual, at your option)
+
+Used for: native MP3 and FLAC decoding (`native/vendor/dr_mp3/`, `native/vendor/dr_flac/`).
+By David Reid (mackron). Both files carry the full dual-licence statement at the end of the header;
+PocketTracker exercises no option and redistributes them unchanged.
+
+---
+
+## stb_vorbis — public domain **or** MIT (dual, at your option)
+
+Used for: native OGG Vorbis decoding (`native/vendor/stb_vorbis/stb_vorbis.c`).
+Copyright (c) 2017 Sean Barrett. The full dual-licence statement is at the end of that file.
+
+---
+
+## nlohmann/json — MIT
+
+Used for: parsing `.ptp` / `.pti` project and instrument JSON (`native/vendor/nlohmann/json.hpp`,
+v3.11.3). Copyright (c) 2013-2022 Niels Lohmann. `SPDX-License-Identifier: MIT` is carried
+throughout the header; MIT text as above.
+
+---
+
+## libogg — BSD-3-Clause
+
+Used for: Ogg container parsing under Opus/Vorbis (`native/vendor/ogg/`).
+Copyright (c) 2002, Xiph.org Foundation. **Full text ships separately** as
+`licenses/libogg-COPYING` (copied verbatim from `native/vendor/ogg/COPYING`).
+
+---
+
+## libopus — BSD-3-Clause
+
+Used for: native Opus decoding (`native/vendor/opus/`). Copyright (c) 2001-2011 Xiph.Org,
+Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell,
+Mark Borgerding, Erik de Castro Lopo. **Full text ships separately** as `licenses/libopus-COPYING`
+(copied verbatim from `native/vendor/opus/COPYING`), alongside `libopus-LICENSE_PLEASE_READ.txt`,
+which is upstream's patent/licensing note and is **not optional reading** despite the name.
+
+---
+
+## opusfile — BSD-3-Clause
+
+Used for: Opus stream/file decoding on top of libopus (`native/vendor/opusfile/`).
+
+> ⚠️ **The vendored copy of opusfile does not include its `COPYING`** — every source file says the
+> work is "GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE", and that file was not
+> carried across when the library was vendored. The notice below reproduces upstream's
+> (github.com/xiph/opusfile) so the pointer in those headers resolves to something.
+
+```
+Copyright (c) 1994-2013 Xiph.Org Foundation and contributors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+- Neither the name of the Xiph.Org Foundation nor the names of its contributors
+  may be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+---
+
+## SDL2 — zlib licence (linked, **not** shipped)
+
+The Linux port links `libSDL2-2.0.so.0` **dynamically against the device's own copy** — the one its
+CFW patched for that hardware's display and audio. PocketTracker ships no SDL2 binary
+(`linux/build-portmaster.sh` asserts `libs.aarch64` is absent), so no SDL2 notice is required in the
+artifact. Recorded here because "we link it" and "we distribute it" are different questions and the
+answer should not have to be re-derived.

--- a/native/kissfft/_kiss_fft_guts.h
+++ b/native/kissfft/_kiss_fft_guts.h
@@ -1,3 +1,11 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See licenses/THIRD-PARTY-NOTICES.md for the full licence text.
+ */
+
 #ifndef KISS_FFT_GUTS_H
 #define KISS_FFT_GUTS_H
 

--- a/native/kissfft/kiss_fft.c
+++ b/native/kissfft/kiss_fft.c
@@ -1,3 +1,11 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See licenses/THIRD-PARTY-NOTICES.md for the full licence text.
+ */
+
 #include "_kiss_fft_guts.h"
 #include <stdlib.h>
 #include <math.h>

--- a/native/kissfft/kiss_fft.h
+++ b/native/kissfft/kiss_fft.h
@@ -1,3 +1,11 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See licenses/THIRD-PARTY-NOTICES.md for the full licence text.
+ */
+
 #ifndef KISS_FFT_H
 #define KISS_FFT_H
 

--- a/native/kissfft/kiss_fftr.c
+++ b/native/kissfft/kiss_fftr.c
@@ -1,3 +1,11 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See licenses/THIRD-PARTY-NOTICES.md for the full licence text.
+ */
+
 #include "kiss_fftr.h"
 #include "_kiss_fft_guts.h"
 #include <stdlib.h>

--- a/native/kissfft/kiss_fftr.h
+++ b/native/kissfft/kiss_fftr.h
@@ -1,3 +1,11 @@
+/*
+ *  Copyright (c) 2003-2010, Mark Borgerding. All rights reserved.
+ *  This file is part of KISS FFT - https://github.com/mborgerding/kissfft
+ *
+ *  SPDX-License-Identifier: BSD-3-Clause
+ *  See licenses/THIRD-PARTY-NOTICES.md for the full licence text.
+ */
+
 #ifndef KISS_FFTR_H
 #define KISS_FFTR_H
 


### PR DESCRIPTION
…arty notice

The release artifact shipped three notices for a binary containing eleven statically linked components, and two of those were missing from the source tree as well. This is a compliance fix, not packaging tidy-up.

- KissFFT was vendored with its copyright banner stripped: not one of the five files in native/kissfft/ carried a copyright line, an SPDX tag, or any licence reference. KissFFT is BSD-3-Clause, whose first two clauses require the notice be retained in source redistributions and reproduced in binary ones -- so this repo and every APK built from it were both non-compliant. The upstream banner is restored to all five files. Comment-only: exactly 8 added lines each and 0 removed, verified by CR-normalised diff against the pristine blobs, with current and pristine both still compiling under gnu99.

- opusfile was vendored without the COPYING that each of its source files points at ("GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE"). Upstream's text is now reproduced in the notices file.

- CREDITS.md claimed DaisySP is MIT. Three of the eight files we compile are LGPL-2.1: compressor (GRAME / CNCM), balance (Vercoe, ffitch, Maldonado) and reverbsc (Costello, Varga, Batchelor), because those descend from Csound and Faust rather than from Electrosmith's own code. There is no compatibility problem, since LGPL-2.1 section 3 permits applying the ordinary GPL v2 "or any later version", so they ship under GPL-3.0-or-later with everything else -- but the attribution was wrong, and is now per-file explicit. nlohmann/json was missing from CREDITS.md entirely.

licenses/THIRD-PARTY-NOTICES.md is now the single source of truth. It covers what is compiled into the engine, i.e. the code shipping in BOTH the APK and the Linux port, and it records SDL2's status too (linked dynamically against the device's own copy, never distributed) because "we link it" and "we distribute it" are different questions that should not need re-deriving.

Found by the Linux port's Phase 5 packaging sweep. Landed on a branch off main rather than the port branch: native/ is shared, so this is an Android obligation as much as a Linux one, and the fdroiddata MR is under review.

Not included here, deliberately: the port zip's own packaging changes (linux/build-portmaster.sh grows a notices guard derived from native/vendor/*) stay on the unpushed sdl-shell branch with the rest of the Linux work.

## What this changes

<!-- Brief description of the change and why -->

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation

## Testing done

<!-- Describe what you tested and on which device/emulator -->

- [ ] Compiles without errors
- [ ] Runs without crash on device or emulator
- [ ] Changed feature works as intended
- [ ] No regressions in phrase/chain/song playback and save/load

## Notes for reviewer

<!-- Anything tricky, open questions, or known limitations -->
