### PR TITLE
fix(ui): theme color for odd file-browser rows instead of hardcoded black

### DIFF
--- a/native/ui/modules/file_browser.cpp
+++ b/native/ui/modules/file_browser.cpp
@@ -372,7 +372,7 @@ void FileBrowserModule::draw(Canvas& c, int x, int y, const FileBrowserState& s,
         if (isCursor)        bg = t.rowCursor;
         else if (isSel)      bg = t.rowSelection;
         else if (i % 2 == 0) bg = t.background;
-        else                 bg = 0xFF111111;
+        else                 bg = t.rowEvery4th;  // theme color instead of hardcoded dark (issue #21)
         c.fill_rect(x, rowY, WIDTH, ROW_HEIGHT, bg);
 
         // Initialized, not merely assigned in every arm below: the `switch` covers all three


### PR DESCRIPTION
Fixes #21.

The file browser hardcoded `0xFF111111` as the background for odd-numbered rows (`file_browser.cpp`, draw loop), ignoring the active theme entirely — so on bright themes odd rows showed up black while even rows followed the theme.

This uses `t.rowEvery4th` for the alternating rows (the subtle accent color themes already define), as suggested in the issue.